### PR TITLE
[BUG] Turbolinks not rendering `voyages/:id` correctly

### DIFF
--- a/app/views/includes/_footer.html.erb
+++ b/app/views/includes/_footer.html.erb
@@ -26,13 +26,13 @@
       <div class="footer-info col-lg-offset-0 col-lg-2 col-md-offset-0 col-md-2 col-sm-offset-0 col-sm-4 col-xs-offset-3 col-xs-6">
         <h6 class="uppercase mb8">follow us</h6>
         <ul class="social-list">
-          <li><a href="https://www.facebook.com/iExpedition-962346843828511/">
+          <li><a href="https://www.facebook.com/iExpedition-962346843828511/" target="_blank">
             <i class="ti-facebook"></i><span class="pl8 social-heading">Facebook</span>
           </a></li>
-          <li><a href="#">
+          <li><a href="https://www.instagram.com/i.expedition/" target="_blank">
             <i class="ti-instagram"></i><span class="pl8 social-heading">Instagram</span>
           </a></li>
-          <li><a href="#">
+          <li><a href="#" target="_blank">
             <i class="ti-dribbble"></i><span class="pl8 social-heading">Blog</span>
           </a></li>
         </ul>

--- a/app/views/pages/about_us.html.erb
+++ b/app/views/pages/about_us.html.erb
@@ -49,10 +49,10 @@
 
         <div class="following-items">
           <div class="facebook-item">
-            <%= image_tag("about/facebook_logo.png") %>
+            <%= link_to image_tag("about/facebook_logo.png"), 'https://www.facebook.com/iExpedition-962346843828511/', target: '_blank' %>
           </div>
           <div class="instagram-item">
-            <%= image_tag("about/instagram_logo.png") %>
+            <%= link_to image_tag("about/instagram_logo.png"), 'https://www.instagram.com/i.expedition/', target: '_blank' %>
           </div>
           <div class="newsletter-item">
             <%= image_tag("about/newsletter_logo.png") %>

--- a/app/views/voyages/show.html.erb
+++ b/app/views/voyages/show.html.erb
@@ -1,3 +1,4 @@
+<body data-turbolinks="false">
 <section class="page-title page-title-2 image-bg overlay parallax">
   <div class="background-image-holder">
     <%= image_tag(@voyage.header_image.url, class: "background-image") %>


### PR DESCRIPTION
Trello ticket: https://trello.com/c/koyNgXnc/44-bug-turbolinks-not-rendering-voyages-id-correctly

### Result
Disabled turbolinks on voyages/show page